### PR TITLE
Fixed Indicators Text

### DIFF
--- a/src/pages/CommercialHub.js
+++ b/src/pages/CommercialHub.js
@@ -23,6 +23,7 @@ import {
   oneDecimalFormatter,
   dollarFormatter,
   options,
+  secondOptions,
   quarterlyFormatter,
   commaFormatter,
   CustomTooltip,
@@ -86,7 +87,11 @@ const CommercialHub = (props) => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in <span className="accentSubText">People Stopping</span> from the same month in 2019
+                {/*Change in <span className="accentSubText">People Stopping</span> from the same month in 2019*/}
+                Change in <span className="accentSubText">People Stopping</span> from {hubMobility.length ?
+                                                    // @ts-ignore
+                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(hubMobility[hubMobility.length - 1]['Month'])))
+                                                    : ''} 2019
               </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
@@ -110,7 +115,11 @@ const CommercialHub = (props) => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in <span className="accentSubText">MBTA Passengers</span> from the same month in 2019
+                {/*Change in <span className="accentSubText">MBTA Passengers</span> from the same month in 2019*/}
+                Change in <span className="accentSubText">MBTA Passengers</span> from {hubValidationSum.length ?
+                                                    // @ts-ignore
+                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(hubValidationSum[hubValidationSum.length - 1]['Month'])))
+                                                    : ''} 2019
               </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
@@ -133,7 +142,13 @@ const CommercialHub = (props) => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext">Change in <span className="accentSubText">Overall In-person Spending</span> from same month in 2019</h4>
+              <h4 className="indicatorSubtext">
+                {/*Change in <span className="accentSubText">Overall In-person Spending</span> from same month in 2019*/}
+                Change in <span className="accentSubText">Overall In-Person Spending</span> from {hubEconomicActivity.length ?
+                                                                    // @ts-ignore
+                                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(hubEconomicActivity[hubEconomicActivity.length - 1]['Month'])))
+                                                                    : ''} 2019
+              </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
                   // once data is loaded, display text. otherwise, show "loading"

--- a/src/pages/EconomicActivity.js
+++ b/src/pages/EconomicActivity.js
@@ -20,6 +20,7 @@ import {
   decimalFormatter,
   oneDecimalFormatter,
   options,
+  secondOptions,
 } from "../utils.js"
 import {
   useDeviceSize
@@ -94,7 +95,12 @@ const EconomicActivity = () => {
         <div className="row mh-20 g-6 indicator-row">
         <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext">Change in <span className="accentSubText">Overall Spending</span> from the Same Month in 2019
+              <h4 className="indicatorSubtext">
+                {/*Change in <span className="accentSubText">Overall Spending</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">Overall In-Person Spending</span> from {spending.length ?
+                                                    // @ts-ignore
+                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(spending[spending.length - 1]['Month'])))
+                                                    : ''} 2019
                 {/* {
                 spending.length ?
                   // @ts-ignore
@@ -122,7 +128,7 @@ const EconomicActivity = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext"><span className="accentSubText">Hotel Occupancy Rate</span></h4>
+              <h4 className="indicatorSubtext"><span className="accentSubText">Hotel Occupancy </span>Rate</h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
                   // once data is loaded, display text. otherwise, show "loading"
@@ -143,7 +149,13 @@ const EconomicActivity = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext">Change in <span className="accentSubText">Restaurant Spending</span> from the Same Month in 2019
+              <h4 className="indicatorSubtext">
+                
+                {/*Change in <span className="accentSubText">Restaurant Spending</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">Restaurant Spending</span> from {spending.length ?
+                                                    // @ts-ignore
+                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(spending[spending.length - 1]['Month'])))
+                                                    : ''} 2019
                 {/* {
                 spending.length ?
                   // @ts-ignore
@@ -172,7 +184,11 @@ const EconomicActivity = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in <span className="accentSubText">Grocery Spending</span> from the Same Month in 2019
+                {/*Change in <span className="accentSubText">Grocery Spending</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">Grocery Spending</span> from {spending.length ?
+                                                    // @ts-ignore
+                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(spending[spending.length - 1]['Month'])))
+                                                    : ''} 2019
                 {/* {
                     dining.length ?
                       // @ts-ignore

--- a/src/pages/LaborMarket.js
+++ b/src/pages/LaborMarket.js
@@ -24,10 +24,13 @@ import {
   oneDecimalFormatter,
   commaFormatter,
   options,
+  secondOptions,
 } from "../utils.js"
 import {
   useDeviceSize
 } from "../useDeviceSize"
+
+
 
 const LaborMarket = () => {
   // set up state variables that will store g-sheet data
@@ -57,7 +60,7 @@ const LaborMarket = () => {
         setUnemployment(dataUnemployment);
         setLaborforce(dataLaborforce);
       })
-
+      
   }, []);
 
   return (
@@ -71,7 +74,10 @@ const LaborMarket = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in Boston <span className="accentSubText">Payroll Employment</span> from same month in 2019
+                Change in Boston <span className="accentSubText">Payroll Employment</span> from {payroll.length ?
+                    // @ts-ignore
+                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(payroll[payroll.length - 1]['Month'])))
+                    : ''} 2019
               </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
@@ -95,7 +101,10 @@ const LaborMarket = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in Boston <span className="accentSubText">Job Postings</span> from same month in 2019
+                  Change in Boston <span className="accentSubText">Job Postings</span> from {payroll.length ?
+                    // @ts-ignore
+                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(postings[postings.length - 1]['Month'])))
+                    : ''} 2019
               </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{

--- a/src/pages/Mobility.js
+++ b/src/pages/Mobility.js
@@ -21,6 +21,7 @@ import {
   oneDecimalFormatter,
   commaFormatter,
   options,
+  secondOptions,
 } from "../utils.js"
 import {
   useDeviceSize
@@ -74,7 +75,11 @@ const Mobility = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in Boston <span className="accentSubText">People Stopping</span> from the Same Month in 2019
+                {/*Change in Boston <span className="accentSubText">People Stopping</span> from the Same Month in 2019*/}
+                Change in Boston <span className="accentSubText">People Stopping</span> from {domestic.length ?
+                                    // @ts-ignore
+                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(domestic[domestic.length - 1]['Month'])))
+                                    : ''} 2019
                 {/* {
                     domestic.length ?
                       // @ts-ignore
@@ -103,7 +108,12 @@ const Mobility = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext">Change in <span className="accentSubText">Logan Airport Domestic Passengers</span> from the Same Month in 2019
+              <h4 className="indicatorSubtext">
+                {/*Change in <span className="accentSubText">Logan Airport Domestic Passengers</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">Logan Airport Domestic Passengers</span> from {logan.length ?
+                                    // @ts-ignore
+                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(logan[logan.length - 1]['Month'])))
+                                    : ''} 2019
                 {/* {
                 logan.length ?
                   // @ts-ignore
@@ -130,7 +140,11 @@ const Mobility = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                Change in <span className="accentSubText">Logan Airport International Passengers</span> from the Same Month in 2019
+                {/*Change in <span className="accentSubText">Logan Airport International Passengers</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">Logan Airport International Passengers</span> from {logan.length ?
+                                    // @ts-ignore
+                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(logan[logan.length - 1]['Month'])))
+                                    : ''} 2019
                 {/* {
                     domestic.length ?
                       // @ts-ignore
@@ -156,7 +170,12 @@ const Mobility = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext">Change in <span className="accentSubText">MBTA Passengers</span> from the Same Month in 2019
+              <h4 className="indicatorSubtext">
+                {/*Change in <span className="accentSubText">MBTA Passengers</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">MBTA Passengers</span> from {MBTA.length ?
+                                    // @ts-ignore
+                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(MBTA[MBTA.length - 1]['Month'])))
+                                    : ''} 2019
                 {/* {
                 MBTA.length ?
                   // @ts-ignoreang 

--- a/src/pages/RealEstateDevelopment.js
+++ b/src/pages/RealEstateDevelopment.js
@@ -21,6 +21,7 @@ import {
   dateFormatter,
   commaFormatter,
   options,
+  secondOptions,
   quarterlyFormatter,
   CustomTooltip,
 } from "../utils.js"
@@ -72,7 +73,7 @@ const RealEstateDevelopment = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                <span className="accentSubText">Net Non-Residential Permitted Square Feet:</span>
+                <span className="accentSubText">Net Non-Residential Permitted Square Feet</span>
               </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
@@ -96,7 +97,7 @@ const RealEstateDevelopment = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext"><span className="accentSubText">Net Permitted Housing Units:</span></h4>
+              <h4 className="indicatorSubtext"><span className="accentSubText">Net Permitted Housing Units</span></h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
                   // once data is loaded, display text. otherwise, show "loading"
@@ -118,7 +119,7 @@ const RealEstateDevelopment = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext"><span className="accentSubText">Net Permitted Income-Restricted Units: </span></h4>
+              <h4 className="indicatorSubtext"><span className="accentSubText">Net Permitted Income-Restricted Units</span></h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4 className="date">{
                   // once data is loaded, display text. otherwise, show "loading"
@@ -162,7 +163,13 @@ const RealEstateDevelopment = () => {
           </div>
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
-              <h4 className="indicatorSubtext"><span className="accentSubText">Change in Construction Hours from the Same Month in 2019</span></h4>
+              <h4 className="indicatorSubtext">
+                {/*Change in <span className="accentSubText">Construction Hours</span> from the Same Month in 2019*/}
+                Change in <span className="accentSubText">Construction Hours</span> from {bjrp.length ?
+                                                                    // @ts-ignore
+                                                                    new Intl.DateTimeFormat("en-US", secondOptions).format((new Date(bjrp[bjrp.length - 1]['Month'])))
+                                                                    : ''} 2019
+              </h4>
               <div className="d-flex flex-row justify-content-around">
                 <h4>{
                   // once data is loaded, display text. otherwise, show "loading"

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,7 @@ export const ordinal = n => {
 
 
 export const options = { month: "long", year: "numeric" };
+export const secondOptions = {month: "long"};
 
 // custom tick for word-wrap labels
 export const CustomXAxisTick = ({ x, y, payload }) => {


### PR DESCRIPTION
Edited indicators text appearing in the Economic Activity, mobility, real estate development, labor market, and commercial hubs tabs to show the actual month in 2019 instead of 'the same month in 2019', makes things faster and easier to read. For now, kept the full month. Can adjust later to just the first three letters of the month. Also removed some weird colons. Didn't edit the code for the orange line mobility indicator text because it's going to be replaced by blue bikes data point.