### PR TITLE
Added Custom MBTA Tooltip

### DIFF
--- a/src/pages/Mobility.js
+++ b/src/pages/Mobility.js
@@ -22,6 +22,8 @@ import {
   commaFormatter,
   options,
   secondOptions,
+  CustomTooltip,
+  MBTACustomTooltip,
 } from "../utils.js"
 import {
   useDeviceSize
@@ -367,7 +369,8 @@ const Mobility = () => {
                 />
                 <ReferenceLine y={0} stroke="#a3a3a3" strokeWidth="2" />
                 <CartesianGrid strokeDasharray="3 3" />
-                <Tooltip labelFormatter={dateFormatter} formatter={commaFormatter} />
+                {/*<Tooltip labelFormatter={dateFormatter} formatter={commaFormatter} content={MBTACustomTooltip}/>*/}
+                <Tooltip labelFormatter={dateFormatter} formatter={commaFormatter} content={MBTACustomTooltip}/>
                 <Legend iconType="plainline" />
                 <Line
                   type="monotone"
@@ -395,7 +398,7 @@ const Mobility = () => {
                 />
               </LineChart>
             </ResponsiveContainer>
-            <p className="citation">Source: MBTA, Gated Station Validations by Station.</p>
+            <p className="citation">Source: MBTA, Gated Station Validations by Station.<br></br>*'All Lines' reflects total gated validations in Boston, ensuring each trip is counted only once, even at transfer stations with multiple lines.</p>
             </div>
         </div>
         <div className="row mh-20 gx-0 gy-0 graph-row">

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,6 +111,21 @@ export const CustomTooltip = (props) => {
     return null;
 };
 
+export const MBTACustomTooltip = (props) => {
+
+    if(props.payload[0]){
+        let total = props.payload[0].payload.Total;
+        const newPayload = [{
+            name:'All Lines*',
+            value:props.payload[0].payload.Total,
+        },...props.payload,
+    ];
+        return <_DefaultTooltipContent.DefaultTooltipContent {...props} payload={newPayload}/>;
+    }
+    return <_DefaultTooltipContent.DefaultTooltipContent {...props} />;
+};
+
+
 // aquire the key of the maximum value in an object 
 // ex: obj {A: 13, B: 4, C: 37}
 // maxKey(obj) returns c


### PR DESCRIPTION
Made edits to Mobility.js to point to MBTACustomTooltip in utils.js. Pulls the total value from the gsheet with all the lines data. Added note to clarify that all lines is not double counting.