### PR TITLE
Real Estate Market Tab Updates, Economy Snapshot Updates

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -64,15 +64,10 @@ function About() {
               about their place of work and commute. The universe includes both payroll workers (those covered under unemployment
               insurance) as well as self-employed workers, and reflects the location survey respondents reported for work in the
               week before the survey, which may be their own home.</p>
-            <li>Total employment in Boston is calculated from two sources:</li>
+            <li>Total payroll employment in Boston:</li>
             <ul>
-              <li>U.S. Bureau of Economic Analysis, Total full-time and part-time employment by NAICS industry</li>
               <li>Massachusetts Executive Office of Labor and Workforce Development, Employment and Wages (ES-202)</li>
             </ul>
-            <p>Total jobs by industry are available from the BEA for Suffolk County. These are allocated to Boston based on
-              the share of payroll jobs in that industry that are located in Boston compared to the balance of the county
-              (Chelsea, Revere, and Winthrop) from ES-202 data. Total jobs include both payroll jobs covered by unemployment
-              insurance as well as self-employment.</p>
           </ul>
 
           <h5>Labor Market</h5>

--- a/src/pages/RealEstateMarket.js
+++ b/src/pages/RealEstateMarket.js
@@ -309,6 +309,7 @@ const RealEstateMarket = () => {
                   type="number"
                   tickFormatter={dollarFormatter}
                   width={80}
+                  domain={[500000, 'auto']}
                 />
 
                 <CartesianGrid strokeDasharray="3 3" />

--- a/src/pages/SnapshotEconomy.js
+++ b/src/pages/SnapshotEconomy.js
@@ -68,7 +68,7 @@ const SnapshotEconomy = () => {
           <div className="col-md justify-content-center text-center">
             <div className="indicatorContainer">
               <h4 className="indicatorSubtext">
-                City of Boston <span className="accentSubText">Total Employment in {
+                City of Boston <span className="accentSubText">Total Payroll Employment in {
                 // once data is loaded, display text. otherwise, show "loading"
                   jobs.length ?
                   // @ts-ignore
@@ -170,7 +170,7 @@ const SnapshotEconomy = () => {
         <div className="row gx-0 econ-row">
           <div className="col-12 col-md-7 graph-column flex-column">
             <div>
-              <h6 className="chartTitle">Total Employment in Boston</h6>
+              <h6 className="chartTitle">Total Payroll Employment in Boston</h6>
               <ResponsiveContainer width="98%" height={graphHeight/1.5}>
                 <BarChart
                   width={500}
@@ -185,7 +185,7 @@ const SnapshotEconomy = () => {
                   <YAxis
                     type="number"
                     width={40}
-                    domain={[500000, 1000000]}
+                    domain={[500000, 750000]}
                     tickFormatter={commaFormatter}
                     tickCount={3}
                   />
@@ -200,10 +200,10 @@ const SnapshotEconomy = () => {
                   />
                 </BarChart>
               </ResponsiveContainer>
-              <p className="citation">Source: U.S. Bureau of Economic Analysis (BEA) and Massachusetts Executive Office of Labor and Workforce Development.</p>
+              <p className="citation">Source: Massachusetts Executive Office of Labor and Workforce Development.</p>
             </div>
             <div>
-              <h6 className="chartTitle">Boston Employment Shares by Industry</h6>
+              <h6 className="chartTitle">Boston Payroll Employment Shares by Industry</h6>
               <p className="subChartTitle">As Compared to Overall U.S. Employment Rate</p>
               <ResponsiveContainer width="98%" height={(graphHeight * 0.9)+(graphHeight/2.3)}>
                 <BarChart
@@ -241,7 +241,7 @@ const SnapshotEconomy = () => {
                   />
                 </BarChart>
               </ResponsiveContainer>
-              <p className="citation">Source: U.S. Bureau of Economic Analysis (BEA) and Massachusetts Executive Office of Labor and Workforce Development.</p>
+              <p className="citation">Source: Massachusetts Executive Office of Labor and Workforce Development. Bureau of Labor Statistics QCEW.</p>
             </div>
           </div>
           <div className="col-12 col-md-5 flex-column econ-column" id="commuterMapCol">


### PR DESCRIPTION
Updated Median Sales chart Y-axis to start at 500k. Updated Economy Overview tab to have corrected sources & added 'payroll' to the title to reflect that BEA no longer a data source and not reflective of all jobs.