### PR TITLE
Updaed CommercialHub - In Person Spending legend

### DIFF
--- a/src/pages/CommercialHub.js
+++ b/src/pages/CommercialHub.js
@@ -312,7 +312,7 @@ const CommercialHub = (props) => {
                 />
                 <Line
                   type="monotone"
-                  dataKey="Eating Places"
+                  dataKey="Restaurants"
                   stroke="#1871bd"
                   dot={false}
                 />


### PR DESCRIPTION
Changed "Eating Places" to "Restaurants" on CommercialHub - In Person Spending